### PR TITLE
Remove extra release

### DIFF
--- a/edm-dashboard.tf
+++ b/edm-dashboard.tf
@@ -21,15 +21,10 @@ resource "heroku_build" "edm_dashboard" {
   }
 }
 
-resource "heroku_app_release" "edm_dashboard" {
-  app     = "${heroku_app.edm_dashboard.name}"
-  slug_id = "${heroku_build.edm_dashboard.slug_id}"
-}
-
 resource "heroku_formation" "edm_dashboard" {
   app        = "${heroku_app.edm_dashboard.name}"
   type       = "web"
   quantity   = "${var.edm_dashboard_count}"
   size       = "${var.edm_dashboard_size}"
-  depends_on = ["heroku_app_release.edm_dashboard"]
+  depends_on = ["heroku_build.edm_dashboard"]
 }

--- a/edm-relay.tf
+++ b/edm-relay.tf
@@ -26,15 +26,10 @@ resource "heroku_build" "edm_relay" {
   }
 }
 
-resource "heroku_app_release" "edm_relay" {
-  app     = "${heroku_app.edm_relay.name}"
-  slug_id = "${heroku_build.edm_relay.slug_id}"
-}
-
 resource "heroku_formation" "edm_relay" {
   app        = "${heroku_app.edm_relay.name}"
   type       = "web"
   quantity   = "${var.edm_relay_count}"
   size       = "${var.edm_relay_size}"
-  depends_on = ["heroku_app_release.edm_relay"]
+  depends_on = ["heroku_build.edm_relay"]
 }

--- a/edm-stats.tf
+++ b/edm-stats.tf
@@ -34,15 +34,10 @@ resource "heroku_build" "edm_stats" {
   }
 }
 
-resource "heroku_app_release" "edm_stats" {
-  app     = "${heroku_app.edm_stats.name}"
-  slug_id = "${heroku_build.edm_stats.slug_id}"
-}
-
 resource "heroku_formation" "edm_stats" {
   app        = "${heroku_app.edm_stats.name}"
   type       = "web"
   quantity   = "${var.edm_stats_count}"
   size       = "${var.edm_stats_size}"
-  depends_on = ["heroku_app_release.edm_stats","heroku_addon.kafka"]
+  depends_on = ["heroku_build.edm_stats","heroku_addon.kafka"]
 }

--- a/edm-stream.tf
+++ b/edm-stream.tf
@@ -26,15 +26,10 @@ resource "heroku_build" "edm_stream" {
   }
 }
 
-resource "heroku_app_release" "edm_stream" {
-  app     = "${heroku_app.edm_stream.name}"
-  slug_id = "${heroku_build.edm_stream.slug_id}"
-}
-
 resource "heroku_formation" "edm_stream" {
   app        = "${heroku_app.edm_stream.name}"
   type       = "web"
   quantity   = "${var.edm_stream_count}"
   size       = "${var.edm_stream_size}"
-  depends_on = ["heroku_app_release.edm_stream","heroku_addon.kafka"]
+  depends_on = ["heroku_build.edm_stream","heroku_addon.kafka"]
 }

--- a/edm-ui.tf
+++ b/edm-ui.tf
@@ -19,15 +19,10 @@ resource "heroku_build" "edm_ui" {
   }
 }
 
-resource "heroku_app_release" "edm_ui" {
-  app     = "${heroku_app.edm_ui.name}"
-  slug_id = "${heroku_build.edm_ui.slug_id}"
-}
-
 resource "heroku_formation" "edm_ui" {
   app        = "${heroku_app.edm_ui.name}"
   type       = "web"
   quantity   = "${var.edm_ui_count}"
   size       = "${var.edm_ui_size}"
-  depends_on = ["heroku_app_release.edm_ui"]
+  depends_on = ["heroku_build.edm_ui"]
 }


### PR DESCRIPTION
Just reading through this setup, and noticed that the recent upgrade to using Terraform provider's `heroku_build` resource can be simplified a bit, because Heroku always creates a new release from a successful build.

I haven't tested applying this yet.